### PR TITLE
feat: add real-time pet stream

### DIFF
--- a/backend/src/controllers/petStreamController.ts
+++ b/backend/src/controllers/petStreamController.ts
@@ -1,0 +1,23 @@
+import { Request, Response } from "express";
+import { petEvents } from "../utils/petEvents";
+import { Pet } from "../entities/Pet";
+
+// Server-Sent Events handler streaming newly created pets in real time
+export const streamNewPets = (req: Request, res: Response): void => {
+  res.setHeader("Content-Type", "text/event-stream");
+  res.setHeader("Cache-Control", "no-cache");
+  res.setHeader("Connection", "keep-alive");
+
+  // write a first comment to establish the stream
+  res.write(": connected\n\n");
+
+  const onNewPet = (pet: Pet) => {
+    res.write(`data: ${JSON.stringify(pet)}\n\n`);
+  };
+
+  petEvents.on("new-pet", onNewPet);
+
+  req.on("close", () => {
+    petEvents.off("new-pet", onNewPet);
+  });
+};

--- a/backend/src/middlewares/auth.ts
+++ b/backend/src/middlewares/auth.ts
@@ -4,14 +4,13 @@ import { AppDataSource } from "../index";
 import { AppUser } from "../entities/User";
 
 export const authMiddleware: RequestHandler = async (req, res, next) => {
-  // let token = req.cookies?.token as string | undefined;
-  let token = "";
+  // Try reading token from query first to support EventSource connections
+  const queryToken = (req as any).query?.token as string | undefined;
+  let token = queryToken || "";
   if (!token) {
     const h = req.get("Authorization");
     if (h?.startsWith("Bearer ")) token = h.slice(7);
   }
-
-  console.log(token);
 
   if (!token) {
     res.status(401).json({ message: "Unauthorized: no token provided" });

--- a/backend/src/routes/pets.ts
+++ b/backend/src/routes/pets.ts
@@ -9,6 +9,7 @@ import {
   updatePet,
   listMyCreatedPets,
 } from "../controllers/petController";
+import { streamNewPets } from "../controllers/petStreamController";
 import { authMiddleware } from "../middlewares/auth";
 
 const router = Router();
@@ -23,5 +24,6 @@ router.get("/mine", listMyCreatedPets);
 router.put("/:petId", updatePet);
 router.post("/:petId/photo", ...uploadPetPhoto);
 router.get("/:petId", getPetById);
+router.get("/stream", streamNewPets);
 
 export default router;

--- a/backend/src/utils/petEvents.ts
+++ b/backend/src/utils/petEvents.ts
@@ -1,0 +1,7 @@
+import { EventEmitter } from "events";
+
+// Global event bus for pet-related realtime notifications
+export const petEvents = new EventEmitter();
+
+// Increase listener limit to avoid warnings when many clients connect
+petEvents.setMaxListeners(50);

--- a/frontend/hooks/usePetStream.ts
+++ b/frontend/hooks/usePetStream.ts
@@ -1,0 +1,27 @@
+import { useEffect } from "react";
+import { Pet } from "@/lib/api";
+
+/**
+ * Subscribe to the backend's SSE stream of newly created pets.
+ * @param onPet callback invoked whenever a new pet is created
+ */
+export function usePetStream(onPet: (pet: Pet) => void) {
+  useEffect(() => {
+    const token =
+      typeof window !== "undefined" ? localStorage.getItem("jwt") : null;
+    const base = process.env.NEXT_PUBLIC_API_URL || "";
+    const url = `${base}/pets/stream${token ? `?token=${token}` : ""}`;
+
+    const ev = new EventSource(url);
+    ev.onmessage = (e) => {
+      try {
+        const pet = JSON.parse(e.data) as Pet;
+        onPet(pet);
+      } catch {
+        /* ignore malformed payloads */
+      }
+    };
+
+    return () => ev.close();
+  }, [onPet]);
+}

--- a/frontend/pages/home.tsx
+++ b/frontend/pages/home.tsx
@@ -42,6 +42,7 @@ import {
 } from "@/components/ui/popover";
 import { Slider } from "@/components/ui/slider";
 import Link from "next/link";
+import { usePetStream } from "@/hooks/usePetStream";
 
 const fetchMatches = () => matchApi.listMyMatches();
 const pageVariants = {
@@ -73,6 +74,11 @@ const Home: NextPage = () => {
   useEffect(() => {
     setCases(matches?.map((m) => m.pet) ?? []);
   }, [matches]);
+
+  // Hook into SSE stream for newly created pets
+  usePetStream((pet) => {
+    toast.success(`New pet available: ${pet.name}`);
+  });
 
   const [index, setIndex] = useState(-1); // start with instructions
   const [flipped, setFlipped] = useState(false);


### PR DESCRIPTION
## Summary
- broadcast newly added pets using server-sent events
- show live notifications in the swipe deck when fresh pets arrive

## Testing
- `pre-commit run --files backend/src/controllers/petController.ts backend/src/middlewares/auth.ts backend/src/routes/pets.ts backend/src/controllers/petStreamController.ts backend/src/utils/petEvents.ts frontend/hooks/usePetStream.ts frontend/pages/home.tsx`
- `cd backend && npm test`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf1b88ec28832cba687553f1c4ee02