### PR TITLE
feat: add adoption application form skeleton (#61)

### DIFF
--- a/frontend/__tests__/adoption-application-form.spec.ts
+++ b/frontend/__tests__/adoption-application-form.spec.ts
@@ -1,0 +1,68 @@
+/* global describe, test, expect */
+import { adoptionApplicationSchema } from "../lib/adoptionApplicationSchema";
+
+const validPayload = {
+  fullName: "Jane Doe",
+  email: "jane@example.com",
+  phone: "555-123-4567",
+  householdSize: "2",
+  housingType: "own" as const,
+  landlordPermission: false,
+  hasOtherPets: false,
+  otherPetsDetails: "",
+  vetOrReferenceContact: "",
+  notes: "",
+};
+
+describe("adoptionApplicationSchema", () => {
+  test("accepts a fully valid payload", () => {
+    const result = adoptionApplicationSchema.safeParse(validPayload);
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects a missing/short full name", () => {
+    const result = adoptionApplicationSchema.safeParse({
+      ...validPayload,
+      fullName: "J",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects an invalid email", () => {
+    const result = adoptionApplicationSchema.safeParse({
+      ...validPayload,
+      email: "not-an-email",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects a missing housing type", () => {
+    const withoutHousingType: Record<string, unknown> = { ...validPayload };
+    delete withoutHousingType.housingType;
+    const result = adoptionApplicationSchema.safeParse(withoutHousingType);
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects notes over 1000 characters", () => {
+    const result = adoptionApplicationSchema.safeParse({
+      ...validPayload,
+      notes: "a".repeat(1001),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("allows optional fields to be omitted", () => {
+    const minimal: Record<string, unknown> = { ...validPayload };
+    for (const key of [
+      "landlordPermission",
+      "hasOtherPets",
+      "otherPetsDetails",
+      "vetOrReferenceContact",
+      "notes",
+    ]) {
+      delete minimal[key];
+    }
+    const result = adoptionApplicationSchema.safeParse(minimal);
+    expect(result.success).toBe(true);
+  });
+});

--- a/frontend/components/AdoptionApplicationForm.tsx
+++ b/frontend/components/AdoptionApplicationForm.tsx
@@ -1,0 +1,407 @@
+"use client";
+
+import React, { useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { motion, AnimatePresence } from "framer-motion";
+import { toast } from "sonner";
+import { Loader2, ArrowLeft, ArrowRight, CheckCircle2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Progress } from "@/components/ui/progress";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import {
+  adoptionApplicationSchema,
+  ADOPTION_APPLICATION_STEP_FIELDS as STEP_FIELDS,
+  ADOPTION_APPLICATION_STEP_TITLES as STEP_TITLES,
+  type AdoptionApplicationValues,
+} from "@/lib/adoptionApplicationSchema";
+
+export type { AdoptionApplicationValues };
+
+interface AdoptionApplicationFormProps {
+  petId: string;
+  petName?: string;
+  /**
+   * Called with a validated payload on final submit.
+   *
+   * NOTE: The `POST /api/adoption-applications` endpoint proposed in
+   * issue #61 doesn't exist yet, so the default behavior below just
+   * simulates a submission. Once the backend lands, pass a real
+   * `onSubmit` handler (e.g. calling `adoptionApi.createApplication`)
+   * from the parent page instead of relying on the default.
+   */
+  onSubmit?: (values: AdoptionApplicationValues) => Promise<void> | void;
+}
+
+export function AdoptionApplicationForm({
+  petId,
+  petName,
+  onSubmit,
+}: AdoptionApplicationFormProps) {
+  const [step, setStep] = useState(0);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+
+  const form = useForm<AdoptionApplicationValues>({
+    resolver: zodResolver(adoptionApplicationSchema),
+    mode: "onBlur",
+    defaultValues: {
+      fullName: "",
+      email: "",
+      phone: "",
+      householdSize: "",
+      housingType: undefined,
+      landlordPermission: false,
+      hasOtherPets: false,
+      otherPetsDetails: "",
+      vetOrReferenceContact: "",
+      notes: "",
+    },
+  });
+
+  const isLastStep = step === STEP_TITLES.length - 1;
+  const progress = ((step + 1) / STEP_TITLES.length) * 100;
+  const housingType = form.watch("housingType");
+  const hasOtherPets = form.watch("hasOtherPets");
+
+  const goNext = async () => {
+    const fieldsToValidate = STEP_FIELDS[step];
+    const valid =
+      fieldsToValidate.length === 0
+        ? true
+        : await form.trigger(fieldsToValidate);
+    if (valid) setStep((s) => Math.min(s + 1, STEP_TITLES.length - 1));
+  };
+
+  const goBack = () => setStep((s) => Math.max(s - 1, 0));
+
+  const handleFinalSubmit = async (values: AdoptionApplicationValues) => {
+    try {
+      setSubmitting(true);
+      if (onSubmit) {
+        await onSubmit(values);
+      } else {
+        // Backend endpoint (POST /api/adoption-applications) is not wired
+        // up yet — see issue #61. Stage the payload locally for now.
+        console.info("[AdoptionApplicationForm] draft payload", {
+          petId,
+          ...values,
+        });
+        await new Promise((resolve) => setTimeout(resolve, 600));
+      }
+      setSubmitted(true);
+      toast.success("Application saved");
+    } catch {
+      toast.error("Something went wrong submitting your application");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (submitted) {
+    return (
+      <Card className="mx-auto max-w-xl">
+        <CardContent className="flex flex-col items-center gap-4 py-12 text-center">
+          <CheckCircle2 className="h-12 w-12 text-[#234851] dark:text-[#B6EBE9]" />
+          <h2 className="text-2xl font-bold text-[#234851] dark:text-[#B6EBE9]">
+            Application received!
+          </h2>
+          <p className="text-muted-foreground max-w-sm">
+            {petName
+              ? `Thanks for applying to adopt ${petName}. `
+              : "Thanks for applying. "}
+            The shelter review queue and status tracking are coming soon —
+            for now this confirms your details were captured successfully.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="mx-auto max-w-xl">
+      <CardHeader className="space-y-4">
+        <CardTitle className="text-2xl text-center text-[#234851] dark:text-[#B6EBE9]">
+          {petName ? `Apply to Adopt ${petName}` : "Adoption Application"}
+        </CardTitle>
+        <div className="space-y-2">
+          <Progress value={progress} className="h-2" />
+          <p className="text-sm text-muted-foreground text-center">
+            Step {step + 1} of {STEP_TITLES.length}: {STEP_TITLES[step]}
+          </p>
+        </div>
+      </CardHeader>
+
+      <CardContent>
+        <Form {...form}>
+          <form
+            onSubmit={form.handleSubmit(handleFinalSubmit)}
+            className="space-y-6"
+          >
+            <AnimatePresence mode="wait">
+              <motion.div
+                key={step}
+                initial={{ opacity: 0, x: 16 }}
+                animate={{ opacity: 1, x: 0 }}
+                exit={{ opacity: 0, x: -16 }}
+                transition={{ duration: 0.2 }}
+                className="space-y-4"
+              >
+                {step === 0 && (
+                  <>
+                    <FormField
+                      control={form.control}
+                      name="fullName"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Full name</FormLabel>
+                          <FormControl>
+                            <Input placeholder="Jane Doe" {...field} />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                    <FormField
+                      control={form.control}
+                      name="email"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Email</FormLabel>
+                          <FormControl>
+                            <Input
+                              type="email"
+                              placeholder="jane@example.com"
+                              {...field}
+                            />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                    <FormField
+                      control={form.control}
+                      name="phone"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Phone number</FormLabel>
+                          <FormControl>
+                            <Input
+                              type="tel"
+                              placeholder="(555) 123-4567"
+                              {...field}
+                            />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                  </>
+                )}
+
+                {step === 1 && (
+                  <>
+                    <FormField
+                      control={form.control}
+                      name="householdSize"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>People in household</FormLabel>
+                          <Select
+                            onValueChange={field.onChange}
+                            defaultValue={field.value}
+                          >
+                            <FormControl>
+                              <SelectTrigger>
+                                <SelectValue placeholder="Select an option" />
+                              </SelectTrigger>
+                            </FormControl>
+                            <SelectContent>
+                              {["1", "2", "3", "4", "5+"].map((n) => (
+                                <SelectItem key={n} value={n}>
+                                  {n}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                    <FormField
+                      control={form.control}
+                      name="housingType"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Housing type</FormLabel>
+                          <Select
+                            onValueChange={field.onChange}
+                            defaultValue={field.value}
+                          >
+                            <FormControl>
+                              <SelectTrigger>
+                                <SelectValue placeholder="Select an option" />
+                              </SelectTrigger>
+                            </FormControl>
+                            <SelectContent>
+                              <SelectItem value="own">I own</SelectItem>
+                              <SelectItem value="rent">I rent</SelectItem>
+                              <SelectItem value="other">Other</SelectItem>
+                            </SelectContent>
+                          </Select>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                    {housingType === "rent" && (
+                      <FormField
+                        control={form.control}
+                        name="landlordPermission"
+                        render={({ field }) => (
+                          <FormItem className="flex flex-row items-start gap-3 space-y-0 rounded-md border p-3">
+                            <FormControl>
+                              <Checkbox
+                                checked={field.value}
+                                onCheckedChange={field.onChange}
+                              />
+                            </FormControl>
+                            <FormLabel className="font-normal">
+                              My landlord allows pets
+                            </FormLabel>
+                          </FormItem>
+                        )}
+                      />
+                    )}
+                  </>
+                )}
+
+                {step === 2 && (
+                  <>
+                    <FormField
+                      control={form.control}
+                      name="hasOtherPets"
+                      render={({ field }) => (
+                        <FormItem className="flex flex-row items-start gap-3 space-y-0 rounded-md border p-3">
+                          <FormControl>
+                            <Checkbox
+                              checked={field.value}
+                              onCheckedChange={field.onChange}
+                            />
+                          </FormControl>
+                          <FormLabel className="font-normal">
+                            I currently have other pets
+                          </FormLabel>
+                        </FormItem>
+                      )}
+                    />
+                    {hasOtherPets && (
+                      <FormField
+                        control={form.control}
+                        name="otherPetsDetails"
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel>Tell us about your other pets</FormLabel>
+                            <FormControl>
+                              <Textarea
+                                placeholder="Species, age, temperament..."
+                                {...field}
+                              />
+                            </FormControl>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                    )}
+                    <FormField
+                      control={form.control}
+                      name="vetOrReferenceContact"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>
+                            Vet or personal reference (optional)
+                          </FormLabel>
+                          <FormControl>
+                            <Input
+                              placeholder="Name and phone/email"
+                              {...field}
+                            />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                  </>
+                )}
+
+                {step === 3 && (
+                  <FormField
+                    control={form.control}
+                    name="notes"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Anything else the shelter should know?</FormLabel>
+                        <FormControl>
+                          <Textarea
+                            placeholder="Optional notes for the shelter"
+                            rows={5}
+                            {...field}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                )}
+              </motion.div>
+            </AnimatePresence>
+
+            <div className="flex items-center justify-between pt-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={goBack}
+                disabled={step === 0 || submitting}
+              >
+                <ArrowLeft className="mr-2 h-4 w-4" />
+                Back
+              </Button>
+
+              {isLastStep ? (
+                <Button type="submit" disabled={submitting}>
+                  {submitting ? (
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  ) : null}
+                  Submit application
+                </Button>
+              ) : (
+                <Button type="button" onClick={goNext}>
+                  Next
+                  <ArrowRight className="ml-2 h-4 w-4" />
+                </Button>
+              )}
+            </div>
+          </form>
+        </Form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/lib/adoptionApplicationSchema.ts
+++ b/frontend/lib/adoptionApplicationSchema.ts
@@ -1,0 +1,60 @@
+import { z } from "zod";
+
+// ──────────────────────────────────────────────────────────────────────────
+// Mirrors the `form_payload` fields proposed for `adoption_applications` in
+// GitHub issue #61. Kept as a single schema (rather than per-step schemas)
+// so validation stays simple; the form only triggers validation for the
+// current step's fields via react-hook-form's `trigger()`.
+//
+// This lives in its own module (rather than inline in the form component)
+// so it has no `@/components/...` imports and can be unit tested directly,
+// since the frontend's current Jest config doesn't resolve the `@/` path
+// alias used throughout the component tree.
+// ──────────────────────────────────────────────────────────────────────────
+export const adoptionApplicationSchema = z.object({
+  // Step 1: contact info
+  fullName: z.string().trim().min(2, "Please enter your full name"),
+  email: z.string().trim().email("Please enter a valid email address"),
+  phone: z.string().trim().min(7, "Please enter a valid phone number"),
+
+  // Step 2: household
+  householdSize: z
+    .string()
+    .min(1, "Please select the number of people in your household"),
+  housingType: z.enum(["own", "rent", "other"], {
+    required_error: "Please select your housing type",
+  }),
+  landlordPermission: z.boolean().optional(),
+
+  // Step 3: pet experience
+  hasOtherPets: z.boolean().optional(),
+  otherPetsDetails: z.string().trim().optional(),
+  vetOrReferenceContact: z.string().trim().optional(),
+
+  // Step 4: notes
+  notes: z
+    .string()
+    .trim()
+    .max(1000, "Notes must be under 1000 characters")
+    .optional(),
+});
+
+export type AdoptionApplicationValues = z.infer<
+  typeof adoptionApplicationSchema
+>;
+
+// Fields validated at each step before allowing "Next".
+export const ADOPTION_APPLICATION_STEP_FIELDS: (keyof AdoptionApplicationValues)[][] =
+  [
+    ["fullName", "email", "phone"],
+    ["householdSize", "housingType"],
+    [], // pet experience fields are all optional
+    [], // notes are optional
+  ];
+
+export const ADOPTION_APPLICATION_STEP_TITLES = [
+  "Contact Information",
+  "Household",
+  "Pet Experience",
+  "Anything Else?",
+];

--- a/frontend/pages/pet/[id].tsx
+++ b/frontend/pages/pet/[id].tsx
@@ -484,6 +484,19 @@ const PetPage: NextPage = () => {
               </div>
             ) : null}
 
+            {/* ────────────────────────────────────────────────────────────────
+                Apply to Adopt (only once the user has swiped "Adopt")
+               ──────────────────────────────────────────────────────────────── */}
+            {user &&
+            mySwipes?.some((s) => s?.pet?.id === pet.id && s.liked) ? (
+              <Button
+                onClick={() => router.push(`/pet/${pet.id}/apply`)}
+                className="w-full bg-teal-700 hover:bg-teal-800 text-white dark:bg-teal-600 dark:hover:bg-teal-500"
+              >
+                Apply to Adopt
+              </Button>
+            ) : null}
+
             {/* Bottom actions */}
             <div className="flex flex-col sm:flex-row gap-3 sm:gap-4">
               <Popover>

--- a/frontend/pages/pet/[id]/apply.tsx
+++ b/frontend/pages/pet/[id]/apply.tsx
@@ -1,0 +1,83 @@
+import React, { useEffect } from "react";
+import type { NextPage } from "next";
+import Head from "next/head";
+import { useRouter } from "next/router";
+import useSWR from "swr";
+import { Loader2, ArrowLeft } from "lucide-react";
+import { motion } from "framer-motion";
+
+import { Layout } from "@/components/Layout";
+import { Button } from "@/components/ui/button";
+import { AdoptionApplicationForm } from "@/components/AdoptionApplicationForm";
+import { useUser } from "@/hooks/useUser";
+import type { Pet } from "@/lib/api";
+
+const fetchPetViaProxy = async ([, id]: readonly [string, string]): Promise<Pet> => {
+  const token =
+    typeof window !== "undefined" ? localStorage.getItem("jwt") : null;
+  const res = await fetch(`/api/pets/${id}`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+  if (!res.ok) throw new Error("Failed to load pet");
+  return res.json();
+};
+
+const ApplyPage: NextPage = () => {
+  const router = useRouter();
+  const rid = router.query.id;
+  const petId = Array.isArray(rid) ? rid[0] : rid;
+  const routeReady = router.isReady && typeof petId === "string";
+
+  const { user, loading: authLoading } = useUser();
+
+  useEffect(() => {
+    if (!authLoading && !user) {
+      router.replace(`/login?next=/pet/${petId ?? ""}/apply`);
+    }
+  }, [authLoading, user, router, petId]);
+
+  const { data: pet, isLoading } = useSWR<Pet>(
+    routeReady ? (["pet", petId as string] as const) : null,
+    fetchPetViaProxy,
+    { revalidateOnFocus: false },
+  );
+
+  if (authLoading || !user || !routeReady) return null;
+
+  return (
+    <Layout>
+      <Head>
+        <title>
+          {pet ? `Apply to Adopt ${pet.name} | PetSwipe` : "Apply | PetSwipe"}
+        </title>
+      </Head>
+
+      <motion.div
+        initial={{ opacity: 0, y: -20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.45 }}
+        className="mx-auto max-w-2xl px-6 py-12"
+      >
+        <Button
+          type="button"
+          variant="ghost"
+          className="mb-6"
+          onClick={() => router.push(`/pet/${petId}`)}
+        >
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          Back to pet profile
+        </Button>
+
+        {isLoading ? (
+          <div className="flex justify-center py-16">
+            <Loader2 className="h-8 w-8 animate-spin text-[#234851] dark:text-[#B6EBE9]" />
+          </div>
+        ) : (
+          <AdoptionApplicationForm petId={petId as string} petName={pet?.name} />
+        )}
+      </motion.div>
+    </Layout>
+  );
+};
+
+export default ApplyPage;


### PR DESCRIPTION
Related to #61
Frontend-only slice of #61: a multi-step adoption application form (AdoptionApplicationForm), a new /pet/[id]/apply page, and an "Apply to Adopt" entry point on the pet detail page for users who've swiped "Adopt".
No backend endpoints exist yet, so submission currently stages the payload locally (console.info) - wiring this up to POST /api/adoption-applications is planned as a follow-up PR once that endpoint lands.
Includes unit tests for the validation schema (6 passing). 
Note: develop branch mentioned in CONTRIBUTING.md doesn't currently exist on this repo, so this PR targets master.
